### PR TITLE
Added error handling to parseFeeds

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -24,8 +24,6 @@ class SimpleRssFeedReaderHelper {
 		// API
 		$mainframe = JFactory::getApplication();
 
-		$cacheTime = $cacheTime*60;
-
 		// Check if the cache folder exists
 		$cacheFolderPath = JPATH_SITE.DS.$cacheLocation;
 		if(file_exists($cacheFolderPath) && is_dir($cacheFolderPath)){

--- a/helper.php
+++ b/helper.php
@@ -144,6 +144,7 @@ class SimpleRssFeedReaderHelper {
 					$msg .= "\n" . $error->message;
 				}
 				JFactory::getApplication()->enqueueMessage($msg);
+				libxml_clear_errors();
 				continue;
 			}
 

--- a/helper.php
+++ b/helper.php
@@ -135,8 +135,23 @@ class SimpleRssFeedReaderHelper {
 		$feedContents = array();
 		foreach($feeds as $key=>$feed){
 			libxml_use_internal_errors(true);
-			$feedContents[$key] = new stdClass;
 			$xml = simplexml_load_string($feed);
+
+			/*
+			 * If the feed didn't parse, generate a warning and skip it
+			 */
+			if ($xml === false) {
+				$msg = "Failed loading XML\n";
+				foreach(libxml_get_errors() as $error) {
+					$msg .= "\n" . $error->message;
+				}
+				JFactory::getApplication()->enqueueMessage($msg);
+				continue;
+			}
+
+			$feedContents[$key] = new stdClass;
+
+
 			if(is_object($xml) && $items = $xml->xpath("/rss/channel/item")) {
 				$feedContents[$key]->feedSubscribeUrl = $feed;
 				$feedContents[$key]->feedTitle = $xml->channel->title;

--- a/tmpl/default/default.php
+++ b/tmpl/default/default.php
@@ -47,7 +47,7 @@ $document->addStyleSheet($filePath.'/css/template.css');
 				<?php endif; ?>
 
 				<?php if($feedItemDescription): ?>
-				<?php echo $feed->itemDescription; ?>
+				<?php echo htmlspecialchars_decode($feed->itemDescription); ?>
 				<?php endif; ?>
 			</p>
 			<?php endif; ?>


### PR DESCRIPTION
Added some error handling, otherwise malformed XML will cause warnings in the foreach().  And it's just kinda helpful to provide feedback on damaged feeds, rather than silently failing.
